### PR TITLE
ensure executables can be found in CF

### DIFF
--- a/script/trigger
+++ b/script/trigger
@@ -4,6 +4,18 @@ set -e
 set -o errexit
 set -o errtrace
 
+# default executable locations
+phantomjs_executable=phantomjs
+fly_executable=fly
+
+# If the runtime is a Cloud Foundry application instance,
+# reference the full paths to the deployed `phantomjs`
+# and `fly` executables.
+if [[ "$CF_INSTANCE_GUID" != "" ]]; then
+    phantomjs_executable=/app/tools/phantomjs/bin/phantomjs
+    fly_executable=/app/tools/fly/fly
+fi
+
 cd $(dirname $0)/..
 
 if [[ "$GITHUB_LDAP_PASSWORD" == "" ]]; then
@@ -30,11 +42,11 @@ echo "triggered by $1"
 
 echo "logging into $CONCOURSE_URL ($CONCOURSE_TARGET) as $GITHUB_LDAP_USERNAME"
 
-token=$(phantomjs --load-images=no --ignore-ssl-errors=yes --debug=no --ssl-protocol=tlsv1 oauth2.js)
+token=$($phantomjs_executable --load-images=no --ignore-ssl-errors=yes --debug=no --ssl-protocol=tlsv1 oauth2.js)
 
-echo $token | fly -t $CONCOURSE_TARGET login -c $CONCOURSE_URL &> /dev/null
+echo $token | $fly_exectuable -t $CONCOURSE_TARGET login -c $CONCOURSE_URL &> /dev/null
 
-fly -t $CONCOURSE_TARGET sync
+$fly_executable -t $CONCOURSE_TARGET sync
 
 echo "triggering job $2"
-fly -t $CONCOURSE_TARGET trigger-job --job $2
+$fly_exectuable -t $CONCOURSE_TARGET trigger-job --job $2


### PR DESCRIPTION
This seeks to ensure that the `fly` and `phantomjs` executables
can be found in their `app/tools` locations in a Cloud Foundry
application instance container.

This may not be regarded as the ideal solution, as it appears `script/tools` seeks to ensure these tools' presence in the `$PATH`. However, I'm hoping this at least gets the ball rolling with regard to further discussion and solutions.

This seeks to fix issue #2 

Thanks!